### PR TITLE
Message Reminder Plugin

### DIFF
--- a/botbot_plugins/base.py
+++ b/botbot_plugins/base.py
@@ -79,6 +79,7 @@ class DummyLine(object):
         self.text = packet['text']
         self.full_text = packet['text']
         self.user = packet.get('User', 'repl_user')
+        self._channel_name = packet.get('Channel', '#dummy-channel')
         self.is_direct_message = self.check_direct_message()
         self._command = packet.get('Command', 'PRIVMSG')
         self._is_message = self._command == 'PRIVMSG'

--- a/botbot_plugins/base.py
+++ b/botbot_plugins/base.py
@@ -4,6 +4,15 @@ import sys
 
 import fakeredis
 
+class PrivateMessage(object):
+    """
+    A holder object for sending a private message.
+    This is used in botbot.apps.plugins.runner
+    """
+    def __init__(self, nick, msg):
+        self.nick = nick
+        self.msg = msg
+
 
 class BasePlugin(object):
     "All plugins inherit this class"
@@ -86,6 +95,12 @@ class DummyLine(object):
 
     def __repr__(self):
         return str(self)
+
+
+class DummyPrivateMessage(object):
+    def __init__(self, nick, msg):
+        self.nick = nick
+        self.msg = msg
 
 
 REPL_INTRO = """
@@ -214,7 +229,11 @@ class DummyApp(Cmd):
                 if match:
                     response = func(line, **match.groupdict())
                     if response:
-                        self.responses.append(response)
-                        self.output('[o__o]: ' + response)
+                        if isinstance(response, PrivateMessage):
+                            self.responses.append(response.msg)
+                            self.output('[o__o]: ' + response.msg)
+                        else:
+                            self.responses.append(response)
+                            self.output('[o__o]: ' + response)
 
 app = DummyApp()

--- a/botbot_plugins/plugins/message_service.py
+++ b/botbot_plugins/plugins/message_service.py
@@ -2,8 +2,7 @@
 Message service plugin
 """
 import json
-from ..base import BasePlugin
-from botbot.apps.plugins.runner import PrivateMessage
+from ..base import BasePlugin, PrivateMessage
 from ..decorators import listens_to_mentions
 
 
@@ -27,12 +26,11 @@ class Plugin(BasePlugin):
             if messages:
                 self.delete(line.user)
                 messages = json.loads(messages)
-                out = "{0} you received the following messages while you were offline.\n".format(line.user)
+                out = "{0} you received the following messages while you were offline.".format(line.user)
                 for message in messages:
                     out += "\n{0}".format(message)
                 return PrivateMessage(line.user, out)
     find_message.route_rule = ('firehose', ur'(.*)')
-
 
     @listens_to_mentions(r'^message\s+(?P<nick>[\w\-_]+)\s+(?P<message>.*)$')
     def store_message(self, line, nick, message):

--- a/botbot_plugins/plugins/message_service.py
+++ b/botbot_plugins/plugins/message_service.py
@@ -1,0 +1,53 @@
+"""
+Message service plugin
+"""
+import json
+from ..base import BasePlugin
+from ..decorators import listens_to_mentions, listens_to_all
+
+
+class Plugin(BasePlugin):
+    """
+    I can leave messages for users who are offline. To have me send
+    a message to your colleague `MrTaubyPants` on your behalf when he
+    comes online, ask me in this format:
+
+        {{ nick }}: message MrTaubyPants Message you want to leave.
+    """
+
+    slug = 'message'
+
+    @listens_to_all(r'^(?P<nick>[\w\-_]+)\s+joined the channel$')
+    def find_message(self, line, nick):
+        """
+        Find any messages for a user after they have logged in.
+        """
+        messages = self.retrieve(nick)
+        if messages:
+            messages = json.loads(messages)
+            out = "{0} you received the following messages while you were offline.".format(nick)
+            for message in messages:
+                out += "\n{0}".format(message)
+            return out
+
+    @listens_to_mentions(r'^message\s+(?P<nick>[\w\-_]+)\s+(?P<message>.*)$')
+    def store_message(self, line, nick, message):
+        """
+        Store a message
+        """
+        message = "From {0} '{1}'".format(
+            line.user, message)
+        # does the user have any messages waiting?
+        messages = self.retrieve(nick)
+
+        if not messages:
+            messages = set()
+        else:
+            messages = set(json.loads(messages))
+
+        messages.add(message)
+        messages = list(messages)
+        self.store(nick, json.dumps(messages))
+        return u"{0}, I will tell {1} when they appear online.".format(
+            line.user, nick)
+

--- a/botbot_plugins/plugins/message_service.py
+++ b/botbot_plugins/plugins/message_service.py
@@ -27,7 +27,7 @@ class Plugin(BasePlugin):
                 self.delete(line.user)
                 messages = json.loads(messages)
                 if hasattr(line, '_channel_name'):
-                    out = "You received the following messages in {0} when you were offline.".format(
+                    out = "Beep BEEP! You received the following messages in {0} when you were offline.".format(
                         line._channel_name)
                 else:
                     out = "You received the following messages when you were offline."

--- a/botbot_plugins/plugins/message_service.py
+++ b/botbot_plugins/plugins/message_service.py
@@ -17,18 +17,19 @@ class Plugin(BasePlugin):
 
     slug = 'message'
 
-    @listens_to_all(r'^(?P<nick>[\w\-_]+)\s+joined the channel$')
-    def find_message(self, line, nick):
+    def find_message(self, line):
         """
         Find any messages for a user after they have logged in.
         """
-        messages = self.retrieve(nick)
-        if messages:
-            messages = json.loads(messages)
-            out = "{0} you received the following messages while you were offline.".format(nick)
-            for message in messages:
-                out += "\n{0}".format(message)
-            return out
+        if line._command == "JOIN":
+            messages = self.retrieve(line.user)
+            if messages:
+                messages = json.loads(messages)
+                out = "{0} you received the following messages while you were offline.".format(line.user)
+                for message in messages:
+                    out += "\n{0}".format(message)
+                return out
+    find_message.route_rule = ('firehose', ur'(.*)')
 
     @listens_to_mentions(r'^message\s+(?P<nick>[\w\-_]+)\s+(?P<message>.*)$')
     def store_message(self, line, nick, message):

--- a/botbot_plugins/plugins/message_service.py
+++ b/botbot_plugins/plugins/message_service.py
@@ -26,10 +26,15 @@ class Plugin(BasePlugin):
             if messages:
                 self.delete(line.user)
                 messages = json.loads(messages)
-                out = "{0} you received the following messages while you were offline.".format(line.user)
+                if hasattr(line, '_channel_name'):
+                    out = "You received the following messages in {0} when you were offline.".format(
+                        line._channel_name)
+                else:
+                    out = "You received the following messages when you were offline."
                 for message in messages:
                     out += "\n{0}".format(message)
                 return PrivateMessage(line.user, out)
+
     find_message.route_rule = ('firehose', ur'(.*)')
 
     @listens_to_mentions(r'^message\s+(?P<nick>[\w\-_]+)\s+(?P<message>.*)$')

--- a/botbot_plugins/plugins/message_service.py
+++ b/botbot_plugins/plugins/message_service.py
@@ -3,7 +3,8 @@ Message service plugin
 """
 import json
 from ..base import BasePlugin
-from ..decorators import listens_to_mentions, listens_to_all
+from botbot.apps.plugins.runner import PrivateMessage
+from ..decorators import listens_to_mentions
 
 
 class Plugin(BasePlugin):
@@ -28,7 +29,7 @@ class Plugin(BasePlugin):
                 out = "{0} you received the following messages while you were offline.".format(line.user)
                 for message in messages:
                     out += "\n{0}".format(message)
-                return out
+                return PrivateMessage(line.user, out)
     find_message.route_rule = ('firehose', ur'(.*)')
 
     @listens_to_mentions(r'^message\s+(?P<nick>[\w\-_]+)\s+(?P<message>.*)$')

--- a/botbot_plugins/tests/test_message_service.py
+++ b/botbot_plugins/tests/test_message_service.py
@@ -30,7 +30,7 @@ def test_remind_user(app):
     responses = app.respond('george joined the channel', **{
         'Command': 'JOIN',
         'User': 'george'})
-    assert responses == ["You received the following messages in #dummy-channel when you were offline.\nFrom repl_user 'Are you going to the meeting?'"]
+    assert responses == ["Beep BEEP! You received the following messages in #dummy-channel when you were offline.\nFrom repl_user 'Are you going to the meeting?'"]
 
 def test_multiple_reminders(app):
     """
@@ -42,6 +42,6 @@ def test_multiple_reminders(app):
     responses = app.respond('george joined the channel', **{
         'Command': 'JOIN',
         'User': 'george'})
-    assert responses == ["You received the following messages in #dummy-channel when you were offline.\nFrom repl_user 'I think I will be going.'\nFrom repl_user 'Are you going to the meeting?'"]
+    assert responses == ["Beep BEEP! You received the following messages in #dummy-channel when you were offline.\nFrom repl_user 'I think I will be going.'\nFrom repl_user 'Are you going to the meeting?'"]
 
 

--- a/botbot_plugins/tests/test_message_service.py
+++ b/botbot_plugins/tests/test_message_service.py
@@ -30,7 +30,7 @@ def test_remind_user(app):
     responses = app.respond('george joined the channel', **{
         'Command': 'JOIN',
         'User': 'george'})
-    assert responses == ["george you received the following messages while you were offline.\nFrom repl_user 'Are you going to the meeting?'"]
+    assert responses == ["You received the following messages in #dummy-channel when you were offline.\nFrom repl_user 'Are you going to the meeting?'"]
 
 def test_multiple_reminders(app):
     """
@@ -42,6 +42,6 @@ def test_multiple_reminders(app):
     responses = app.respond('george joined the channel', **{
         'Command': 'JOIN',
         'User': 'george'})
-    assert responses == ["george you received the following messages while you were offline.\nFrom repl_user 'I think I will be going.'\nFrom repl_user 'Are you going to the meeting?'"]
+    assert responses == ["You received the following messages in #dummy-channel when you were offline.\nFrom repl_user 'I think I will be going.'\nFrom repl_user 'Are you going to the meeting?'"]
 
 

--- a/botbot_plugins/tests/test_message_service.py
+++ b/botbot_plugins/tests/test_message_service.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+Message service tests
+"""
+import pytest
+from botbot_plugins.base import DummyApp
+from botbot_plugins.plugins import message_service
+
+
+@pytest.fixture
+def app():
+    return DummyApp(test_plugin=message_service.Plugin())
+
+
+def test_remember(app):
+    """
+    [d__d]: message user foobar
+    """
+    responses = app.respond(r'@message george Are you going to the meeting?')
+    assert responses == [u'repl_user, I will tell george when they appear online.']
+
+
+def test_remind_user(app):
+    """
+    george joined the channel.
+    """
+    responses = app.respond(r'@message george Are you going to the meeting?')
+    assert responses == [u'repl_user, I will tell george when they appear online.']
+
+    responses = app.respond('george joined the channel')
+    assert responses == ["george you received the following messages while you were offline.\nFrom repl_user 'Are you going to the meeting?'"]
+
+def test_multiple_reminders(app):
+    """
+    Multiple reminders should work too.
+    """
+    responses = app.respond(r'@message george Are you going to the meeting?')
+    responses = app.respond(r'@message george I think I will be going.')
+
+    responses = app.respond('george joined the channel')
+    assert responses == ["george you received the following messages while you were offline.\nFrom repl_user 'I think I will be going.'\nFrom repl_user 'Are you going to the meeting?'"]
+

--- a/botbot_plugins/tests/test_message_service.py
+++ b/botbot_plugins/tests/test_message_service.py
@@ -30,8 +30,7 @@ def test_remind_user(app):
     responses = app.respond('george joined the channel', **{
         'Command': 'JOIN',
         'User': 'george'})
-    assert responses == ["george you received the following messages while you were offline.\n *From repl_user 'Are you going to the meeting?'"]
-
+    assert responses == ["george you received the following messages while you were offline.\nFrom repl_user 'Are you going to the meeting?'"]
 
 def test_multiple_reminders(app):
     """
@@ -43,6 +42,6 @@ def test_multiple_reminders(app):
     responses = app.respond('george joined the channel', **{
         'Command': 'JOIN',
         'User': 'george'})
-    assert responses == ["george you received the following messages while you were offline.\n *From repl_user 'I think I will be going.' *From repl_user 'Are you going to the meeting?'"]
+    assert responses == ["george you received the following messages while you were offline.\nFrom repl_user 'I think I will be going.'\nFrom repl_user 'Are you going to the meeting?'"]
 
 


### PR DESCRIPTION
This plugin stores messages for offline users. When the user returns to the room, botbot
will send the user a private message of what they missed while offline.

* Add support in ``DummyApp`` for testing firehose plugins
* Add storage ``delete``
* Alter ``app.responds`` to take additional ``kwargs`` that to simulate ``JOIN``, ``QUIT``, etc actions.